### PR TITLE
Replace bitnami Kafka image with soldevelo/kafka

### DIFF
--- a/packages/kafka/docker-compose.yml
+++ b/packages/kafka/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   kafka-broker-1:
-    image: bitnami/kafka:latest
+    image: soldevelo/kafka:latest
     container_name: kafka-broker-1
     environment:
       KAFKA_ENABLE_KRAFT: "yes"
@@ -19,7 +19,7 @@ services:
     networks:
       - kafka-network
   kafka-broker-2:
-    image: bitnami/kafka:latest
+    image: soldevelo/kafka:latest
     container_name: kafka-broker-2
     environment:
       KAFKA_ENABLE_KRAFT: "yes"
@@ -38,7 +38,7 @@ services:
     networks:
       - kafka-network
   kafka-broker-3:
-    image: bitnami/kafka:latest
+    image: soldevelo/kafka:latest
     container_name: kafka-broker-3
     environment:
       KAFKA_ENABLE_KRAFT: "yes"


### PR DESCRIPTION
Soldevelo image is a drop-in replacement that remains fully compatible with Bitnami’s configuration and environment variables.

The Bitnami Kafka image is now behind a paywall and no longer publicly available, which prevents CI/CD and local environments from functioning properly.
Switching to Soldevelo’s maintained image ensures:
* continued compatibility with existing Kafka setup,
* availability of regular updates and security patches,
* use of an image from a trusted and open source provider.